### PR TITLE
Client key handling improvements and some other stuff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,64 @@
 .cache
 __pycache__
+
+*~
+*.autosave
+*.a
+*.core
+*.moc
+*.o
+*.obj
+*.orig
+*.rej
+*.so
+*.so.*
+*_pch.h.cpp
+*_resource.rc
+*.qm
+.#*
+*.*#
+.clangd
+core
+!core/
+tags
+.DS_Store
+.directory
+*.debug
+Makefile*
+*.prl
+*.app
+moc_*.cpp
+ui_*.h
+qrc_*.cpp
+Thumbs.db
+*.res
+*.rc
+/.qmake.cache
+/.qmake.stash
+
+# xemacs temporary files
+*.flc
+
+# Vim temporary files
+.*.swp
+
+# Visual Studio generated files
+*.ib_pdb_index
+*.idb
+*.ilk
+*.pdb
+*.sln
+*.suo
+*.vcproj
+*vcproj.*.*.user
+*.ncb
+*.sdf
+*.opensdf
+*.vcxproj
+*vcxproj.*
+
+# Visual Studio Code generated files
+.vscode
+
+# Python byte code
+*.pyc

--- a/client_keys.json
+++ b/client_keys.json
@@ -1,0 +1,7 @@
+{
+    "public": {
+        "CLIENT_ID": "5af907e805114b54ad674b1765447cf4",
+        "CLIENT_SECRET": "6cc582cd14894babad8fc9043ae7a982"
+    },
+    "personal": {}
+}

--- a/fuzzy_recs.py
+++ b/fuzzy_recs.py
@@ -16,8 +16,18 @@ from fuzzysearch import find_near_matches
 
 
 # Client Keys
-CLIENT_ID = "5af907e805114b54ad674b1765447cf4"
-CLIENT_SECRET = "6cc582cd14894babad8fc9043ae7a982"
+with open("client_keys.json", "r") as keys:
+    client_keys = json.loads(keys.read())
+    try:
+        if client_keys["personal"]["CLIENT_ID"] and client_keys["personal"]["CLIENT_SECRET"]:
+            CLIENT_ID = client_keys["personal"]["CLIENT_ID"]
+            CLIENT_SECRET = client_keys["personal"]["CLIENT_SECRET"]
+        else:
+            CLIENT_ID = client_keys["public"]["CLIENT_ID"]
+            CLIENT_SECRET = client_keys["public"]["CLIENT_SECRET"]
+    except KeyError:    # In case the personal key is undefined in the json
+        CLIENT_ID = client_keys["public"]["CLIENT_ID"]
+        CLIENT_SECRET = client_keys["public"]["CLIENT_SECRET"]
 
 # Spotify API URIs
 SPOTIFY_TOKEN_URL = "https://accounts.spotify.com/api/token"

--- a/hopidy.py
+++ b/hopidy.py
@@ -60,9 +60,9 @@ def ffplay(song):
 def queue_check():
 	global music_dir
 	global queue_dir
-	music_dir = os.path.join(spotipy_dir, 'music')
-	queue_dir = os.path.join(spotipy_dir, 'queue')
-	playlist_dir = os.path.join(spotipy_dir, 'playlists')
+	music_dir = os.path.join(melodine_dir, 'music')
+	queue_dir = os.path.join(melodine_dir, 'queue')
+	playlist_dir = os.path.join(melodine_dir, 'playlists')
 	while True:
 		for song in now_playing:
 			if song == 'placeholder':

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,16 @@
-pip install -r requirements.txt
-spotipy_dir = os.path.join(os.path.expanduser('~'), 'SpotiPy')
-if not os.path.exists(spotipy_dir):
-	os.mkdir(spotipy_dir)
-	os.mkdir(os.path.join(spotipy_dir, 'music'))
-	os.mkdir(os.path.join(spotipy_dir, 'queue'))
-	os.mkdir(os.path.join(spotipy_dir, 'cover_art_dir'))
-	os.mkdir(os.path.join(spotipy_dir, 'playlists'))
+import os
+
+print("== Melodine Setup ==")
+print("\nInstalling required dependencies...\n")
+
+os.system("pip install -r requirements.txt")
+
+print("\n...done\n")
+
+melodine_dir = os.path.join(os.path.expanduser('~'), '.melodine')
+if not os.path.exists(melodine_dir):
+	os.mkdir(melodine_dir)
+	os.mkdir(os.path.join(melodine_dir, 'music'))
+	os.mkdir(os.path.join(melodine_dir, 'queue'))
+	os.mkdir(os.path.join(melodine_dir, 'cover_art_dir'))
+	os.mkdir(os.path.join(melodine_dir, 'playlists'))

--- a/utils.py
+++ b/utils.py
@@ -68,8 +68,8 @@ now_playing.append('placeholder')
 global status_dir
 status_dir = {}
 
-global spotipy_dir
-spotipy_dir = os.path.join(os.path.expanduser('~'), 'SpotiPy')
+global melodine_dir
+melodine_dir = os.path.join(os.path.expanduser('~'), '.melodine')
 queue_dir = os.path.join(os.path.expanduser('~'), 'queue')
 music_dir = os.path.join(os.path.expanduser('~'), 'music')
 #endregion
@@ -135,9 +135,9 @@ def get_music(search_term, save_as, out_dir, sleep_val = 0, part = True):
 		if save_as == None:
 			save_as = search_term
 
-		spotipy_dir = os.path.join(os.path.expanduser('~'), 'SpotiPy')
+		melodine_dir = os.path.join(os.path.expanduser('~'), '.melodine')
 
-		music_dir = os.path.join(spotipy_dir, out_dir)
+		music_dir = os.path.join(melodine_dir, out_dir)
 		formatted_search_term = filter_search_term.replace(' ', '+')
 
 		html = urllib.request.urlopen(
@@ -273,7 +273,7 @@ def put_notification(song):
 	if image_urls is not None:
 		print('\r---image_urls is not None \n>>> ', end = ' ')
 		get_image(image_urls['mid'], track)
-		image_path = os.path.join(spotipy_dir, 'cover_art_dir', f'{track}.png')
+		image_path = os.path.join(melodine_dir, 'cover_art_dir', f'{track}.png')
 	else:
 		image_path = None
 
@@ -287,7 +287,7 @@ def put_notification(song):
 
 def get_image(image_url, song):
 	image_data = requests.get(image_url)
-	with open(os.path.join(spotipy_dir, 'cover_art_dir', f'{song}.png'), 'wb') as le_image:
+	with open(os.path.join(melodine_dir, 'cover_art_dir', f'{song}.png'), 'wb') as le_image:
 		le_image.write(image_data.content)
 
 def get_metadata(song_name):

--- a/utils.py
+++ b/utils.py
@@ -8,6 +8,7 @@ import re
 import string
 import socket
 import traceback
+from json import loads
 from ffpyplayer.player import MediaPlayer
 from spotipy.oauth2 import SpotifyClientCredentials
 import spotipy
@@ -16,6 +17,21 @@ from pynotifier import Notification
 import tqdm
 import fuzzy_recs
 import math
+#endregion
+
+#region Client Key Assignment
+with open("client_keys.json", "r") as keys:
+    client_keys = loads(keys.read())
+    try:
+        if client_keys["personal"]["CLIENT_ID"] and client_keys["personal"]["CLIENT_SECRET"]:
+            CLIENT_ID = client_keys["personal"]["CLIENT_ID"]
+            CLIENT_SECRET = client_keys["personal"]["CLIENT_SECRET"]
+        else:
+            CLIENT_ID = client_keys["public"]["CLIENT_ID"]
+            CLIENT_SECRET = client_keys["public"]["CLIENT_SECRET"]
+    except KeyError:    # In case the personal key is undefined in the json
+        CLIENT_ID = client_keys["public"]["CLIENT_ID"]
+        CLIENT_SECRET = client_keys["public"]["CLIENT_SECRET"]
 #endregion
 
 #region Global Variables
@@ -37,7 +53,7 @@ global prev_track
 prev_track = None
 
 global spot
-spot = spotipy.Spotify(client_credentials_manager = SpotifyClientCredentials('5af907e805114b54ad674b1765447cf4', '6cc582cd14894babad8fc9043ae7a982'))
+spot = spotipy.Spotify(client_credentials_manager = SpotifyClientCredentials(CLIENT_ID, CLIENT_SECRET))
 
 global recommendations
 recommendations = []
@@ -218,7 +234,7 @@ def get_recs(name):
 
 	global prev_search
 
-	spot = spotipy.Spotify(client_credentials_manager = SpotifyClientCredentials('5af907e805114b54ad674b1765447cf4', '6cc582cd14894babad8fc9043ae7a982'))
+	spot = spotipy.Spotify(client_credentials_manager = SpotifyClientCredentials(CLIENT_ID, CLIENT_SECRET))
 
 	track_results = spot.search(name, type = 'track')
 
@@ -278,7 +294,7 @@ def get_metadata(song_name):
 	try:
 		search_str = song_name
 
-		spot = spotipy.Spotify(client_credentials_manager = SpotifyClientCredentials('5af907e805114b54ad674b1765447cf4', '6cc582cd14894babad8fc9043ae7a982'))
+		spot = spotipy.Spotify(client_credentials_manager = SpotifyClientCredentials(CLIENT_ID, CLIENT_SECRET))
 
 		track = spot.search(search_str)
 


### PR DESCRIPTION
(Copied and pasted from the commit descriptions lol)

Client ID and Secret are now stored in two categories in the `client_keys.json` file, and the program fetches the keys from the same file. The `public` key contains the default client keys, and the user can add their own client keys under the `personal` key in the JSON file. Also, added a HUGE bunch of file formats to the `.gitignore` file.

Fixed the `setup.py` file so it actually works now lol. Also, changed the name of the `spotipy_dir` variable to `melodine_dir` and changed the name of the folder created in the home dir from `SpotiPy` to `.melodine`